### PR TITLE
Fix uncaught exception (exception was thrown within callback)

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -1,5 +1,6 @@
 import js.node.*;
 import js.node.http.*;
+import js.Promise;
 
 class Main {
 	static function parseAuth(s:String)
@@ -45,22 +46,43 @@ class Main {
 
 	static function update(remote, local, callback)
 	{
-		trace("updating: fetching");
-		fetch(local, function (ferr, stdout, stderr) {
-			if (ferr != null) {
-				trace("updating: fetch failed, cloning");
-				clone(remote, local, function (cerr, stdout, stderr) {
-					if (cerr != null) {
-						callback('git clone exited with non-zero status: ${cerr.code}');
+		if (!updatePromises.exists(local)) {
+			updatePromises[local] = new Promise(function(resolve, reject) {
+				trace("updating: fetching");
+				fetch(local, function (ferr, stdout, stderr) {
+					if (ferr != null) {
+						trace("updating: fetch failed, cloning");
+						clone(remote, local, function (cerr, stdout, stderr) {
+							if (cerr != null) {
+								resolve('git clone exited with non-zero status: ${cerr.code}');
+							} else {
+								trace("updating: success");
+								resolve(null);
+							}
+						});
 					} else {
 						trace("updating: success");
-						callback(null);
+						resolve(null);
 					}
 				});
-			} else {
-				trace("updating: success");
-				callback(null);
-			}
+			})
+			.then(function(success) {
+				updatePromises.remove(local);
+				return Promise.resolve(success);
+			})
+			.catchError(function(err) {
+				updatePromises.remove(local);
+				return Promise.reject(err);
+			});
+		} else {
+			trace("reusing existing promise");
+		}
+		return updatePromises[local]
+		.then(function(nothing:Dynamic) {
+			trace("promise fulfilled");
+			callback(null);
+		}, function(err:Dynamic) {
+			callback(err);
 		});
 	}
 
@@ -142,6 +164,7 @@ class Main {
 		}
 	}
 
+	static var updatePromises = new Map<String, Promise<Dynamic>>();
 	static var cacheDir = "/tmp/var/cache/git/";
 	static var listenPort = 8080;
 	static var usage = "

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -96,7 +96,11 @@ class Main {
 				if (params.isInfoRequest) {
 					update(remote, local, function (err) {
 						if (err != null) {
-							throw err;
+							trace('ERROR: $err');
+							trace(haxe.CallStack.toString(haxe.CallStack.exceptionStack()));
+							res.statusCode = 500;
+							res.end();
+							return;
 						}
 						res.statusCode = 200;
 						res.setHeader("Content-Type", 'application/x-${params.service}-advertisement');

--- a/src/Main.hx
+++ b/src/Main.hx
@@ -50,14 +50,16 @@ class Main {
 			if (ferr != null) {
 				trace("updating: fetch failed, cloning");
 				clone(remote, local, function (cerr, stdout, stderr) {
-					if (cerr != null)
-						throw 'git clone exited with non-zero status: ${cerr.code}';
-					trace("updating: success");
-					callback();
+					if (cerr != null) {
+						callback('git clone exited with non-zero status: ${cerr.code}');
+					} else {
+						trace("updating: success");
+						callback(null);
+					}
 				});
 			} else {
 				trace("updating: success");
-				callback();
+				callback(null);
 			}
 		});
 	}
@@ -92,7 +94,10 @@ class Main {
 				}
 
 				if (params.isInfoRequest) {
-					update(remote, local, function () {
+					update(remote, local, function (err) {
+						if (err != null) {
+							throw err;
+						}
 						res.statusCode = 200;
 						res.setHeader("Content-Type", 'application/x-${params.service}-advertisement');
 						res.setHeader("Cache-Control", "no-cache");


### PR DESCRIPTION
From time to time the process is just terminating:

```
Aug 17 14:27:47 c1 env[13680]: GET /github.com/arangodb/arangodb/info/refs?service=git-upload-pack
Aug 17 14:27:47 c1 env[13680]: authenticating on the upstream repo
Aug 17 14:27:48 c1 env[13680]: updating: fetching
Aug 17 14:27:49 c1 env[13680]: updating: success
Aug 17 14:27:50 c1 env[13680]: git-upload-pack done with exit 0
Aug 17 14:27:50 c1 env[13680]: updating: fetch failed, cloning
Aug 17 14:27:50 c1 env[13680]: /usr/lib/node_modules/git-cache-http-server/bin/git-cache-http-server.js:91
Aug 17 14:27:50 c1 env[13680]:                                         throw new js__$Boot_HaxeError("git clone exited with non-zero status: " + cerr.code);
Aug 17 14:27:50 c1 env[13680]:                                         ^
Aug 17 14:27:50 c1 env[13680]: Error: git clone exited with non-zero status: 128
Aug 17 14:27:50 c1 env[13680]:     at /usr/lib/node_modules/git-cache-http-server/bin/git-cache-http-server.js:91:12
Aug 17 14:27:50 c1 env[13680]:     at ChildProcess.exithandler (child_process.js:212:5)
Aug 17 14:27:50 c1 env[13680]:     at emitTwo (events.js:106:13)
Aug 17 14:27:50 c1 env[13680]:     at ChildProcess.emit (events.js:194:7)
Aug 17 14:27:50 c1 env[13680]:     at maybeClose (internal/child_process.js:899:16)
Aug 17 14:27:50 c1 env[13680]:     at Socket.<anonymous> (internal/child_process.js:342:11)
Aug 17 14:27:50 c1 env[13680]:     at emitOne (events.js:96:13)
Aug 17 14:27:50 c1 env[13680]:     at Socket.emit (events.js:191:7)
Aug 17 14:27:50 c1 env[13680]:     at Pipe._handle.close [as _onclose] (net.js:511:12)
Aug 17 14:27:50 c1 systemd[1]: git-cache-http.service: Main process exited, code=exited, status=1/FAILURE
Aug 17 14:27:50 c1 systemd[1]: git-cache-http.service: Unit entered failed state.
Aug 17 14:27:50 c1 systemd[1]: git-cache-http.service: Failed with result 'exit-code'.```
```

The reason for this is that the exception is being thrown within an async callback and so it will not be catched and the process just dies.

This fix should fix it. Not sure if this is the clean way in Haxe.

Btw: this thing is awesome 🥇 