### PR TITLE
increase request timeout limit to 120 minutes

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -219,7 +219,8 @@ Options:
 
 		trace('INFO: cache directory: $cacheDir');
 		trace('INFO: listening to port: $listenPort');
-		Http.createServer(handleRequest).listen(listenPort);
+		var server = Http.createServer(handleRequest);
+		server.setTimeout(120*60*1000); // 120 * 60 seconds * 1000 msecs
+		server.listen(listenPort);
 	}
 }
-


### PR DESCRIPTION
If initial clone is taking long time on server, then client will receive 'Empty reply from server' after 2 minutes (default timeout of node.js http server). E.g.
```
$ time git clone http://localhost:8080/github.com/kubernetes/kubernetes                 
Cloning into 'kubernetes'...
fatal: unable to access 'http://localhost:8080/github.com/kubernetes/kubernetes/': Empty reply from server

real	2m0.118s
user	0m0.000s
sys	0m0.006s
```

This PR allows server initial clone to take up to 2 hours, while client is waiting for reply.

PS: 
Thanks for creating this project. I can see that the goal of this is to improve performance of git clones/fetches from remote hosts, such as github. Can you tell me why did you choose Haxe? 
I was recently considering creating a project like this, to speed up clones on a on-premises CI agents. In a highly concurrent environment with rather slow link to the internet. I was thinking that it could be implemented with [libgit2](https://github.com/libgit2/libgit2) + some efficient http server which can handle many requests with good performance. I was thinking of dotnet core and kestrel. Since you basically implemented a proof of concept already, what do you think? 
