### PR TITLE
Prune objects that have been deleted in the remote

### DIFF
--- a/src/Main.hx
+++ b/src/Main.hx
@@ -55,7 +55,7 @@ class Main {
 	static function fetch(remote, local, callback)
 	{
 		ChildProcess.exec('git -C "$local" remote set-url origin "$remote"', function(err, stdout, stderr) {
-			ChildProcess.exec('git -C "$local" fetch --quiet', callback);
+			ChildProcess.exec('git -C "$local" fetch --quiet --prune --prune-tags', callback);
 		});
 	}
 


### PR DESCRIPTION
This keeps the cache consistent with the contents of the remote.